### PR TITLE
Rewrite NeighborCache implementation

### DIFF
--- a/dev_pins.md
+++ b/dev_pins.md
@@ -340,25 +340,26 @@ http://www.glprogramming.com/red/index.html
 ### Neighbor block caching for stuff like context-sensitive render states
 ```java
 public final class NeighborCache <T> {
-    private final BlockPos origin;
     private final Map<BlockPos, T> cache = new HashMap<>();
-    private final Function<BlockPos, T> generator;
+
+    private final BlockPos origin;
+    private final Function<BlockPos, T> computer;
 
     public NeighborCache(BlockPos origin, Function<BlockPos, T> generator) {
         this.origin = origin.toImmutable();
-        this.generator = generator;
+        this.computer = pos -> generator.apply(this.origin.add(pos));
     }
 
     public NeighborCache(Function<BlockPos, T> generator) {
         this(BlockPos.ORIGIN, generator);
     }
 
-    public T get(int x, int y, int z) {
-        return get(new BlockPos(x, y, z));
+    public T get(BlockPos offset) {
+        return cache.computeIfAbsent(offset, computer);
     }
 
-    public T get(BlockPos offset) {
-        return computeIfAbsent(offset);
+    public T get(int x, int y, int z) {
+        return get(new BlockPos(x, y, z));
     }
 
     public T get(EnumFacing offset) {
@@ -371,10 +372,6 @@ public final class NeighborCache <T> {
 
     public T get(EnumFacing offset1, EnumFacing offset2, EnumFacing offset3) {
         return get(BlockPos.ORIGIN.offset(offset1).offset(offset2).offset(offset3));
-    }
-
-    private T computeIfAbsent(BlockPos pos) {
-        return cache.computeIfAbsent(pos, it -> generator.apply(it.add(origin)));
     }
 }
 ```


### PR DESCRIPTION
 - Mark fields that should not be accessed externally as private and final
 - Migrate cache lookup to use the appropriate computeIfAbsent function
 - Improve parameter names of various getters
 - Migrate example use cases to use method references
 - Add BlockPos#toImmutable call to passed BlockPos in constructor to avoid MutableBlockPos leaks