### PR TITLE
Added more curseforge maven infomation

### DIFF
--- a/dev_pins.md
+++ b/dev_pins.md
@@ -160,7 +160,7 @@ dependencies {
     deobfCompile "<curse-slug>:<jarname>:<version>"
 }
 ```
-Note that version needed for the `deobfCompile` relies on the jarname being in the format: `modid-mcversion-modversion.jar`. This is not always the case, meaning that it can be difficult to figure out the correct infomation to add. There is a tool that figures out this infomation for you:
+Note that version and jarname needed for the `deobfCompile` relies on the jarname being in the format: `modid-mcversion-modversion.jar`. This is not always the case, meaning that it can be difficult to figure out the correct infomation to add. There is a tool that figures out this infomation for you:
 https://github.com/Wyn-Price/CurseForge-Maven-Helper/
 ### A way to check if you are running in a dev environment
 ```java

--- a/dev_pins.md
+++ b/dev_pins.md
@@ -157,10 +157,11 @@ maven {
 . . .
 
 dependencies {
-compile "<curse-slug>:<jarname>:<version>"
+    deobfCompile "<curse-slug>:<jarname>:<version>"
 }
 ```
-
+Note that version needed for the `deobfCompile` relies on the jarname being in the format: `modid-mcversion-modversion.jar`. This is not always the case, meaning that it can be difficult to figure out the correct infomation to add. There is a tool that figures out this infomation for you:
+https://github.com/Wyn-Price/CurseForge-Maven-Helper/
 ### A way to check if you are running in a dev environment
 ```java
 public static boolean isDevEnv() {


### PR DESCRIPTION
The curseforge maven currently relies on the jarname being in a certain format `modid-mcversion-modversion.jar` to get the version and the `<jarname>` needed for the build.grade. Although MOST mods seem to do this, there are a few which don't, meaning that current information of `<curse-slug>:<jarname>:<version>` won't always work. I've linked my tool that I made that deals with the all this, and works out the correct information to put in the `build.gradle`. 
 
Also, in the dependencies block, I don't know why you put `compile` instead of `deobfCompile`, as most mods uploaded without a classifier won't be the debof version. The `-dev` is (seemingly) the common classifier for debof versions. I think it makes more sense to put `deobfCompile` instead of just `compile`, as even if the jar is debof, it won't cause issues.  
 
The curseforge maven is also apparently getting a redo soon(ish), which is good, as relying on the jarname to get your version isn't a good idea.