### PR TITLE
Update dev_pins.md

### DIFF
--- a/dev_pins.md
+++ b/dev_pins.md
@@ -267,9 +267,6 @@ TextureAtlasSprite texture = ModelLoader.defaultTextureGetter().apply(fluid.getF
 ### 1.11 to 1.12 class name changes
 https://github.com/ModCoderPack/MCPBot-Issues/wiki/1.11.0-to-1.12.0-migration
 
-### Config system exemple
-https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/test/java/net/minecraftforge/test/ConfigurationTest.java
-
 ### Mob stuff
 ###### AI Task
 The red task will run when the entity#getAttackTarget != null. And as long as the target is null, the green tasks will run in order to set an attack target.

--- a/dev_pins.md
+++ b/dev_pins.md
@@ -23,7 +23,7 @@ https://github.com/Shadows-of-Fire/How2Mod/blob/master/Instructions.txt/
 
 https://github.com/TheGreyGhost/MinecraftByExample/ 1.8.9/1.10.2/1.11.2
 
-https://web.archive.org/web/20161119034729/http://bedrockminer.jimdo.com:80/modding-tutorials 1.7.10/1.8.9
+https://web.archive.org/web/20170629194638/https://bedrockminer.jimdo.com/modding-tutorials 1.7.10/1.8.9
 
 http://www.wuppy29.com/minecraft/modding-tutorials/forge-modding/#sthash.WeP0PGW2.dpbs/ 1.3.2/1.4/1.5.1/1.6/1.7.10/1.8.9
 

--- a/dev_pins.md
+++ b/dev_pins.md
@@ -23,7 +23,7 @@ https://github.com/Shadows-of-Fire/How2Mod/blob/master/Instructions.txt/
 
 https://github.com/TheGreyGhost/MinecraftByExample/ 1.8.9/1.10.2/1.11.2
 
-https://bedrockminer.jimdo.com/modding-tutorials/ 1.7.10/1.8.9
+https://web.archive.org/web/20161119034729/http://bedrockminer.jimdo.com:80/modding-tutorials 1.7.10/1.8.9
 
 http://www.wuppy29.com/minecraft/modding-tutorials/forge-modding/#sthash.WeP0PGW2.dpbs/ 1.3.2/1.4/1.5.1/1.6/1.7.10/1.8.9
 
@@ -268,7 +268,7 @@ TextureAtlasSprite texture = ModelLoader.defaultTextureGetter().apply(fluid.getF
 https://github.com/ModCoderPack/MCPBot-Issues/wiki/1.11.0-to-1.12.0-migration
 
 ### Config system exemple
-https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/test/java/net/minecraftforge/debug/ConfigTest.java
+https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/test/java/net/minecraftforge/test/ConfigurationTest.java
 
 ### Mob stuff
 ###### AI Task


### PR DESCRIPTION
Bedrockminer has left the scene and as such his tutorials are not longer available in the old way. I updated the link to point to the Archive.org version of the page.

The 1.12.2 Configuration Test was no longer in existence, I updated it with new path and filename in the Forge repository. Ironically it still does not use the ANNOTATION system.