### PR TITLE
Added a link describing how to fix a run-time bug very specific to Eclipse

### DIFF
--- a/dev_pins.md
+++ b/dev_pins.md
@@ -457,3 +457,6 @@ more concise but you need to know more Java: http://www.minecraftforum.net/forum
 ### Coding practice
 https://www.hackerrank.com/
 
+### Troubleshooting Eclipse development with other mods
+https://github.com/MinecraftForge/ForgeGradle/issues/519#issuecomment-423849322
+


### PR DESCRIPTION
I've added a link to the dev-pins change linking to a ForgeGradle issue describing how to troubleshoot a bug specific to Eclipse that prevents the dev from running mods side-by-side with Eclipse. Normally, you'd want to put another mod in the run/mods folder, but Eclipse may have ASM issues with this; by removing a VM argument, you can rectify this bug.

This solution is not for everyone, but there are very few resources available on this, and it could save people who do experience this bug a significant amount of effort in determining what is wrong if it were more publicly known. 